### PR TITLE
Update currency rate drivers structure

### DIFF
--- a/Driver/CurrencyDriverInterface.php
+++ b/Driver/CurrencyDriverInterface.php
@@ -9,24 +9,28 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\CurrencyExchangeBundle\Currency;
+namespace ONGR\CurrencyExchangeBundle\Driver;
 
 /**
- * This interface defines structure for currency rates download driver.
+ * This interface defines methods for currency driver.
+ *
+ * Currency driver is a service that provides currency rates from single source.
  */
 interface CurrencyDriverInterface
 {
     /**
-     * Returns array of currency rates. For example: <code>['USD' => 1, 'EUR' => '1.678']</code>.
+     * Returns array of currency rates.
+     *
+     * For example: <code>['USD' => 1, 'EUR' => '1.678']</code>.
      *
      * @return array
      */
     public function getRates();
 
     /**
-     * Returns default currency name.
+     * Returns base currency code.
      *
      * @return string
      */
-    public function getDefaultCurrencyName();
+    public function getBaseCurrency();
 }

--- a/Driver/EcbDriver.php
+++ b/Driver/EcbDriver.php
@@ -9,9 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\CurrencyExchangeBundle\Currency\Drivers;
-
-use ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface;
+namespace ONGR\CurrencyExchangeBundle\Driver;
 
 /**
  * This class downloads exchange rates from http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml.
@@ -36,12 +34,11 @@ class EcbDriver implements CurrencyDriverInterface
     }
 
     /**
-     * Default base currency of The European Central Bank.
-     *
      * {@inheritdoc}
      */
-    public function getDefaultCurrencyName()
+    public function getBaseCurrency()
     {
+        // Default base currency of The European Central Bank
         return 'EUR';
     }
 }

--- a/Driver/OpenExchangeRatesDriver.php
+++ b/Driver/OpenExchangeRatesDriver.php
@@ -9,9 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\CurrencyExchangeBundle\Currency\Drivers;
+namespace ONGR\CurrencyExchangeBundle\Driver;
 
-use ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface;
 use GuzzleHttp\Client;
 
 /**
@@ -82,7 +81,7 @@ class OpenExchangeRatesDriver implements CurrencyDriverInterface
         }
 
         // Check if base currency is correct.
-        if ($response['base'] != $this->getDefaultCurrencyName()) {
+        if ($response['base'] != $this->getBaseCurrency()) {
             throw new \UnexpectedValueException(
                 sprintf(
                     'We expected to get values in base currency USD. Got %s',
@@ -95,9 +94,9 @@ class OpenExchangeRatesDriver implements CurrencyDriverInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
-    public function getDefaultCurrencyName()
+    public function getBaseCurrency()
     {
         return 'USD';
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,8 +2,8 @@ parameters:
     # Currency rate
     ongr_currency_exchange.currency_rates_service.class: ONGR\CurrencyExchangeBundle\Service\CurrencyRatesService
     ongr_currency_exchange.currency_exchange_service.class: ONGR\CurrencyExchangeBundle\Service\CurrencyExchangeService
-    ongr_currency_exchange.open_exchange_driver.class: ONGR\CurrencyExchangeBundle\Currency\Drivers\OpenExchangeRatesDriver
-    ongr_currency_exchange.ecb_driver.class: ONGR\CurrencyExchangeBundle\Currency\Drivers\EcbDriver
+    ongr_currency_exchange.open_exchange_driver.class: ONGR\CurrencyExchangeBundle\Driver\OpenExchangeRatesDriver
+    ongr_currency_exchange.ecb_driver.class: ONGR\CurrencyExchangeBundle\Driver\EcbDriver
 
     # Currency display extension
     ongr_currency_exchange.twig.price_extension.class: ONGR\CurrencyExchangeBundle\Twig\PriceExtension

--- a/Resources/doc/currency_driver.md
+++ b/Resources/doc/currency_driver.md
@@ -39,7 +39,7 @@ See example below:
 
 namespace AppBundle\Service;
 
-use ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface;
+use ONGR\CurrencyExchangeBundle\Driver\CurrencyDriverInterface;
 
 class CurrencyDriver implements CurrencyDriverInterface
 {
@@ -52,7 +52,7 @@ class CurrencyDriver implements CurrencyDriverInterface
         ];
     }
     
-    public function getDefaultCurrencyName()
+    public function getBaseCurrency()
     {
         return 'EUR';
     }

--- a/Service/CurrencyRatesService.php
+++ b/Service/CurrencyRatesService.php
@@ -12,9 +12,9 @@
 namespace ONGR\CurrencyExchangeBundle\Service;
 
 use Elasticsearch\Common\Exceptions\Missing404Exception;
-use ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface;
 use ONGR\CurrencyExchangeBundle\Document\CurrencyDocument;
 use ONGR\CurrencyExchangeBundle\Document\RatesObject;
+use ONGR\CurrencyExchangeBundle\Driver\CurrencyDriverInterface;
 use ONGR\CurrencyExchangeBundle\Exception\RatesNotLoadedException;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;
@@ -190,6 +190,6 @@ class CurrencyRatesService implements LoggerAwareInterface
      */
     public function getBaseCurrency()
     {
-        return $this->driver->getDefaultCurrencyName();
+        return $this->driver->getBaseCurrency();
     }
 }

--- a/Tests/Unit/Service/CurrencyRatesServiceTest.php
+++ b/Tests/Unit/Service/CurrencyRatesServiceTest.php
@@ -108,13 +108,13 @@ class CurrencyRatesServiceTest extends \PHPUnit_Framework_TestCase
      * @param string     $base  Base currency name.
      * @param null|array $rates Currency rates.
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject|\ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|\ONGR\CurrencyExchangeBundle\Driver\CurrencyDriverInterface
      */
     private function getDriverMock($base, $rates = null)
     {
-        $mock = $this->getMock('ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface');
+        $mock = $this->getMock('ONGR\CurrencyExchangeBundle\Driver\CurrencyDriverInterface');
         $mock->expects($this->any())->method('getRates')->will($this->returnValue($rates));
-        $mock->expects($this->any())->method('getDefaultCurrencyName')->will($this->returnValue($base));
+        $mock->expects($this->any())->method('getBaseCurrency')->will($this->returnValue($base));
 
         return $mock;
     }

--- a/Tests/fixture/Currency/CurrencyDriverService.php
+++ b/Tests/fixture/Currency/CurrencyDriverService.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\CurrencyExchangeBundle\Tests\fixture\Currency;
 
-use ONGR\CurrencyExchangeBundle\Currency\CurrencyDriverInterface;
+use ONGR\CurrencyExchangeBundle\Driver\CurrencyDriverInterface;
 
 /**
  * This class provides fixture for currency getter.
@@ -33,7 +33,7 @@ class CurrencyDriverService implements CurrencyDriverInterface
     /**
      * {@inheritdoc}
      */
-    public function getDefaultCurrencyName()
+    public function getBaseCurrency()
     {
         return 'EUR';
     }


### PR DESCRIPTION
Moved all driver-related stuff to `Driver` namespace. Also renamed method to get base currency code.

Closes #30