### PR TITLE
Do not silent errors

### DIFF
--- a/Driver/EcbDriver.php
+++ b/Driver/EcbDriver.php
@@ -22,7 +22,7 @@ class EcbDriver implements CurrencyDriverInterface
     public function getRates()
     {
         $rates = [];
-        $xml = @simplexml_load_file('http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
+        $xml = simplexml_load_file('http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml');
         $data = $xml->xpath('//gesmes:Envelope/*[3]/*');
         foreach ($data[0]->children() as $child) {
             $code = (string)$child->attributes()->currency;

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -75,5 +75,3 @@ services:
         class: ONGR\CurrencyExchangeBundle\Tests\FooSettingsProvider
         tags:
             - { name: ongr_currency_exchange.settings_provider, method: getFooSets } # method attribute is optional
-
-


### PR DESCRIPTION
> Use `simplexml_load_file` parameters instead of `@` tag to silent errors and/or warnings if actually needed.

Remove error/warning prevention from EcbDriver.